### PR TITLE
[SW-21] Lock history table on migration

### DIFF
--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTable.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTable.java
@@ -1,0 +1,9 @@
+package org.schemawizard.core.analyzer;
+
+public interface HistoryTable {
+    void createIfNotExists();
+
+    boolean exists();
+
+    void lockForMigrationExecution();
+}

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTable.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTable.java
@@ -5,5 +5,5 @@ public interface HistoryTable {
 
     boolean exists();
 
-    void lockForMigrationExecution();
+    void lockForExecution();
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTableCreator.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/HistoryTableCreator.java
@@ -1,7 +1,0 @@
-package org.schemawizard.core.analyzer;
-
-public interface HistoryTableCreator {
-    void createTableIfNotExist();
-
-    boolean historyTableExists();
-}

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/factory/impl/DowngradeFactoryImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/factory/impl/DowngradeFactoryImpl.java
@@ -7,8 +7,8 @@ import org.schemawizard.core.analyzer.model.ContextDowngradeStrategyParameters;
 import org.schemawizard.core.analyzer.model.DowngradeStrategyParameters;
 import org.schemawizard.core.analyzer.model.VersionDowngradeStrategyParameters;
 import org.schemawizard.core.analyzer.service.DowngradeStrategy;
-import org.schemawizard.core.dao.ConnectionHolder;
 import org.schemawizard.core.dao.HistoryTableQueryFactory;
+import org.schemawizard.core.dao.TransactionService;
 import org.schemawizard.core.metadata.ErrorMessage;
 
 import java.sql.PreparedStatement;
@@ -16,14 +16,14 @@ import java.sql.SQLException;
 import java.util.function.Function;
 
 public class DowngradeFactoryImpl implements DowngradeFactory {
-    private final ConnectionHolder connectionHolder;
+    private final TransactionService transactionService;
     private final HistoryTableQueryFactory historyTableQueryFactory;
 
     public DowngradeFactoryImpl(
-            ConnectionHolder connectionHolder,
+            TransactionService transactionService,
             HistoryTableQueryFactory historyTableQueryFactory
     ) {
-        this.connectionHolder = connectionHolder;
+        this.transactionService = transactionService;
         this.historyTableQueryFactory = historyTableQueryFactory;
     }
 
@@ -44,12 +44,14 @@ public class DowngradeFactoryImpl implements DowngradeFactory {
         return new DowngradeStrategy() {
             @Override
             public <T> T apply(Function<PreparedStatement, T> action) {
-                try (PreparedStatement statement = connectionHolder.getConnection().prepareStatement(historyTableQueryFactory.getSelectMigrationsStartedFromSqlOrderByIdDesc())) {
-                    statement.setInt(1, parameters.getVersion());
-                    return action.apply(statement);
-                } catch (SQLException exception) {
-                    throw new MigrationAnalyzerException(exception.getMessage(), exception);
-                }
+                return transactionService.doWithinTransaction(connection -> {
+                    try (PreparedStatement statement = connection.prepareStatement(historyTableQueryFactory.getSelectMigrationsStartedFromSqlOrderByIdDesc())) {
+                        statement.setInt(1, parameters.getVersion());
+                        return action.apply(statement);
+                    } catch (SQLException exception) {
+                        throw new MigrationAnalyzerException(exception.getMessage(), exception);
+                    }
+                });
             }
 
             @Override
@@ -63,13 +65,15 @@ public class DowngradeFactoryImpl implements DowngradeFactory {
         return new DowngradeStrategy() {
             @Override
             public <T> T apply(Function<PreparedStatement, T> action) {
-                try (PreparedStatement statement = connectionHolder.getConnection().prepareStatement(historyTableQueryFactory.getSelectLastMigrationsByContext())) {
-                    statement.setString(1, parameters.getContext());
-                    statement.setString(2, parameters.getContext());
-                    return action.apply(statement);
-                } catch (SQLException exception) {
-                    throw new MigrationAnalyzerException(exception.getMessage(), exception);
-                }
+                return transactionService.doWithinTransaction(connection -> {
+                    try (PreparedStatement statement = connection.prepareStatement(historyTableQueryFactory.getSelectLastMigrationsByContext())) {
+                        statement.setString(1, parameters.getContext());
+                        statement.setString(2, parameters.getContext());
+                        return action.apply(statement);
+                    } catch (SQLException exception) {
+                        throw new MigrationAnalyzerException(exception.getMessage(), exception);
+                    }
+                });
             }
 
             @Override

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/factory/impl/DowngradeFactoryImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/factory/impl/DowngradeFactoryImpl.java
@@ -11,7 +11,6 @@ import org.schemawizard.core.dao.ConnectionHolder;
 import org.schemawizard.core.dao.HistoryTableQueryFactory;
 import org.schemawizard.core.metadata.ErrorMessage;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.function.Function;
@@ -45,10 +44,7 @@ public class DowngradeFactoryImpl implements DowngradeFactory {
         return new DowngradeStrategy() {
             @Override
             public <T> T apply(Function<PreparedStatement, T> action) {
-                try (
-                        Connection connection = connectionHolder.getConnection();
-                        PreparedStatement statement = connection.prepareStatement(historyTableQueryFactory.getSelectMigrationsStartedFromSqlOrderByIdDesc())
-                ) {
+                try (PreparedStatement statement = connectionHolder.getConnection().prepareStatement(historyTableQueryFactory.getSelectMigrationsStartedFromSqlOrderByIdDesc())) {
                     statement.setInt(1, parameters.getVersion());
                     return action.apply(statement);
                 } catch (SQLException exception) {
@@ -67,10 +63,7 @@ public class DowngradeFactoryImpl implements DowngradeFactory {
         return new DowngradeStrategy() {
             @Override
             public <T> T apply(Function<PreparedStatement, T> action) {
-                try (
-                        Connection connection = connectionHolder.getConnection();
-                        PreparedStatement statement = connection.prepareStatement(historyTableQueryFactory.getSelectLastMigrationsByContext())
-                ) {
+                try (PreparedStatement statement = connectionHolder.getConnection().prepareStatement(historyTableQueryFactory.getSelectLastMigrationsByContext())) {
                     statement.setString(1, parameters.getContext());
                     statement.setString(2, parameters.getContext());
                     return action.apply(statement);

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/HistoryTableImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/HistoryTableImpl.java
@@ -51,9 +51,9 @@ public class HistoryTableImpl implements HistoryTable {
     }
 
     @Override
-    public void lockForMigrationExecution() {
+    public void lockForExecution() {
         try (Statement statement = connectionHolder.getConnection().createStatement()) {
-            statement.executeUpdate(historyTableQueryFactory.getLockForMigrationExecutionSql());
+            statement.executeUpdate(historyTableQueryFactory.getLockForExecutionSql());
         } catch (SQLException exception) {
             throw new MigrationAnalyzerException(
                     String.format(

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/HistoryTableImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/HistoryTableImpl.java
@@ -2,8 +2,8 @@ package org.schemawizard.core.analyzer.impl;
 
 import org.schemawizard.core.analyzer.HistoryTable;
 import org.schemawizard.core.analyzer.exception.MigrationAnalyzerException;
-import org.schemawizard.core.dao.ConnectionHolder;
 import org.schemawizard.core.dao.HistoryTableQueryFactory;
+import org.schemawizard.core.dao.TransactionService;
 import org.schemawizard.core.metadata.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,50 +15,56 @@ import static org.schemawizard.core.dao.Constants.MIGRATION_TABLE_NAME;
 
 public class HistoryTableImpl implements HistoryTable {
     private final Logger log = LoggerFactory.getLogger(HistoryTableImpl.class);
-    private final ConnectionHolder connectionHolder;
+    private final TransactionService transactionService;
     private final HistoryTableQueryFactory historyTableQueryFactory;
 
-    public HistoryTableImpl(ConnectionHolder connectionHolder, HistoryTableQueryFactory historyTableQueryFactory) {
-        this.connectionHolder = connectionHolder;
+    public HistoryTableImpl(TransactionService transactionService, HistoryTableQueryFactory historyTableQueryFactory) {
+        this.transactionService = transactionService;
         this.historyTableQueryFactory = historyTableQueryFactory;
     }
 
     @Override
     public void createIfNotExists() {
-        try (Statement statement = connectionHolder.getConnection().createStatement()) {
-            statement.execute(historyTableQueryFactory.getAcquireAdvisoryLockSql());
-            statement.execute(historyTableQueryFactory.getSelectTableSql());
-            if (!statement.getResultSet().next()) {
-                statement.execute(historyTableQueryFactory.getCreateMigrationHistoryTableSql());
-                log.info("Migration history table created.");
-            } else {
-                log.info("Migration history table already exists.");
+        transactionService.doWithinTransaction(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(historyTableQueryFactory.getAcquireAdvisoryLockSql());
+                statement.execute(historyTableQueryFactory.getSelectTableSql());
+                if (!statement.getResultSet().next()) {
+                    statement.execute(historyTableQueryFactory.getCreateMigrationHistoryTableSql());
+                    log.info("Migration history table created.");
+                } else {
+                    log.info("Migration history table already exists.");
+                }
+                statement.execute(historyTableQueryFactory.getReleaseAdvisoryLockSql());
+            } catch (SQLException e) {
+                throw new MigrationAnalyzerException("Error creating migration history table: " + e.getMessage(), e);
             }
-            statement.execute(historyTableQueryFactory.getReleaseAdvisoryLockSql());
-        } catch (SQLException e) {
-            throw new MigrationAnalyzerException("Error creating migration history table: " + e.getMessage(), e);
-        }
+        });
     }
 
     @Override
     public boolean exists() {
-        try (Statement statement = connectionHolder.getConnection().createStatement()) {
-            statement.execute(historyTableQueryFactory.getSelectTableSql());
-            return statement.getResultSet().next();
-        } catch (SQLException e) {
-            throw new MigrationAnalyzerException(e.getMessage(), e);
-        }
+        return transactionService.doWithinTransaction(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(historyTableQueryFactory.getSelectTableSql());
+                return statement.getResultSet().next();
+            } catch (SQLException e) {
+                throw new MigrationAnalyzerException(e.getMessage(), e);
+            }
+        });
     }
 
     @Override
     public void lockForExecution() {
-        try (Statement statement = connectionHolder.getConnection().createStatement()) {
-            statement.executeUpdate(historyTableQueryFactory.getLockForExecutionSql());
-        } catch (SQLException exception) {
-            throw new MigrationAnalyzerException(
-                    String.format(
-                            ErrorMessage.UNABLE_TO_LOCK_TABLE_TEMPLATE,
-                            MIGRATION_TABLE_NAME));
-        }
+        transactionService.doWithinTransaction(connection -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.executeUpdate(historyTableQueryFactory.getLockForExecutionSql());
+            } catch (SQLException exception) {
+                throw new MigrationAnalyzerException(
+                        String.format(
+                                ErrorMessage.UNABLE_TO_LOCK_TABLE_TEMPLATE,
+                                MIGRATION_TABLE_NAME));
+            }
+        });
     }
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/MigrationAnalyzerImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/impl/MigrationAnalyzerImpl.java
@@ -47,7 +47,7 @@ public class MigrationAnalyzerImpl implements MigrationAnalyzer {
 
     @Override
     public List<MigrationData> upgradeAnalyze() {
-        historyTable.lockForMigrationExecution();
+        historyTable.lockForExecution();
         var appliedMigrations = appliedMigrationsService.getAppliedMigrations();
         Map<Integer, DeclaredMigration> versionDeclaredMigrationsMap = createVersionDeclaredMigrationMap();
         for (AppliedMigration migration : appliedMigrations) {
@@ -68,6 +68,7 @@ public class MigrationAnalyzerImpl implements MigrationAnalyzer {
         if (!historyTable.exists()) {
             throw new MigrationAnalyzerException("No migrations has been found, run upgrade first");
         }
+        historyTable.lockForExecution();
         DowngradeStrategy strategy = downgradeFactory.getInstance(parameters);
         var appliedMigrationsToDowngrade = appliedMigrationsService.getMigrationsByDowngradeStrategy(strategy);
         if (appliedMigrationsToDowngrade.isEmpty()) {

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/service/impl/AppliedMigrationsServiceImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/analyzer/service/impl/AppliedMigrationsServiceImpl.java
@@ -20,7 +20,6 @@ import static org.schemawizard.core.dao.Constants.ID;
 import static org.schemawizard.core.dao.Constants.VERSION;
 
 public class AppliedMigrationsServiceImpl implements AppliedMigrationsService {
-
     private final ConnectionHolder connectionHolder;
     private final HistoryTableQueryFactory historyTableQueryFactory;
 

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/HistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/HistoryTableQueryFactory.java
@@ -15,7 +15,7 @@ public interface HistoryTableQueryFactory {
 
     String getDeleteMigrationHistoryRowQuery();
 
-    String getLockForMigrationExecutionSql();
+    String getLockForExecutionSql();
 
     String getAcquireAdvisoryLockSql();
 

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/HistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/HistoryTableQueryFactory.java
@@ -14,4 +14,10 @@ public interface HistoryTableQueryFactory {
     String getInsertMigrationHistoryRowQuery();
 
     String getDeleteMigrationHistoryRowQuery();
+
+    String getLockForMigrationExecutionSql();
+
+    String getAcquireAdvisoryLockSql();
+
+    String getReleaseAdvisoryLockSql();
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/TransactionService.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/TransactionService.java
@@ -5,4 +5,6 @@ import java.util.function.Function;
 
 public interface TransactionService {
     <T> T doWithinTransaction(Function<Connection, T> action);
+
+    void doWithinTransaction(Runnable action);
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/TransactionService.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/TransactionService.java
@@ -1,10 +1,13 @@
 package org.schemawizard.core.dao;
 
 import java.sql.Connection;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public interface TransactionService {
     <T> T doWithinTransaction(Function<Connection, T> action);
+
+    void doWithinTransaction(Consumer<Connection> action);
 
     void doWithinTransaction(Runnable action);
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
@@ -10,6 +10,10 @@ import static org.schemawizard.core.dao.Constants.MIGRATION_TABLE_NAME;
 import static org.schemawizard.core.dao.Constants.VERSION;
 
 public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory {
+    private final static String METADATA_TABLE_NAME = "USER_TABLES";
+    private final static String MIGRATION_HISTORY_TABLE_CREATION_LOCK_NAME = "SCHEMAWIZARD_LOCK";
+    private final static String MIGRATION_EXECUTION_LOCK_NAME = "SCHEMAWIZARD_EXECUTION_LOCK";
+
     @Override
     public String getCreateMigrationHistoryTableSql() {
         return String.format("CREATE TABLE %s ("
@@ -31,8 +35,9 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
     @Override
     public String getSelectTableSql() {
         return String.format("SELECT table_name "
-                        + "FROM USER_TABLES "
+                        + "FROM %s "
                         + "WHERE LOWER(table_name)='%s'",
+                METADATA_TABLE_NAME,
                 MIGRATION_TABLE_NAME);
     }
 
@@ -81,7 +86,7 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
     @Override
     public String getInsertMigrationHistoryRowQuery() {
         return String.format(
-                "INSERT INTO %s (%s, %s, %s) VALUES (?, ?)",
+                "INSERT INTO %s (%s, %s, %s) VALUES (?, ?, ?)",
                 MIGRATION_TABLE_NAME,
                 VERSION,
                 DESCRIPTION,
@@ -94,5 +99,44 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
                 "DELETE FROM %s WHERE %s = ?",
                 MIGRATION_TABLE_NAME,
                 VERSION);
+    }
+
+    @Override
+    public String getLockForMigrationExecutionSql() {
+        return String.format(
+                "DECLARE\n" +
+                        "  l_lock_handle VARCHAR2(128);\n" +
+                        "  l_result NUMBER;\n" +
+                        "BEGIN\n" +
+                        "  DBMS_LOCK.ALLOCATE_UNIQUE('%s', l_lock_handle);\n" +
+                        "  l_result := DBMS_LOCK.REQUEST(l_lock_handle, DBMS_LOCK.X_MODE);\n" +
+                        "END;",
+                MIGRATION_EXECUTION_LOCK_NAME);
+    }
+
+    @Override
+    public String getAcquireAdvisoryLockSql() {
+        return String.format(
+                "DECLARE\n" +
+                        "  l_lock_handle VARCHAR2(128);\n" +
+                        "  l_result NUMBER;\n" +
+                        "BEGIN\n" +
+                        "  DBMS_LOCK.ALLOCATE_UNIQUE('%s', l_lock_handle);\n" +
+                        "  l_result := DBMS_LOCK.REQUEST(l_lock_handle, DBMS_LOCK.X_MODE);\n" +
+                        "END;",
+                MIGRATION_HISTORY_TABLE_CREATION_LOCK_NAME);
+    }
+
+    @Override
+    public String getReleaseAdvisoryLockSql() {
+        return String.format(
+                "DECLARE\n" +
+                        "  l_lock_handle VARCHAR2(128);\n" +
+                        "  l_result NUMBER;\n" +
+                        "BEGIN\n" +
+                        "  DBMS_LOCK.ALLOCATE_UNIQUE('%s', l_lock_handle);\n" +
+                        "  l_result := DBMS_LOCK.RELEASE(l_lock_handle);\n" +
+                        "END;",
+                MIGRATION_HISTORY_TABLE_CREATION_LOCK_NAME);
     }
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
@@ -12,7 +12,7 @@ import static org.schemawizard.core.dao.Constants.VERSION;
 public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory {
     private final static String METADATA_TABLE_NAME = "USER_TABLES";
     private final static String MIGRATION_HISTORY_TABLE_CREATION_LOCK_NAME = "SCHEMAWIZARD_LOCK";
-    private final static String MIGRATION_EXECUTION_LOCK_NAME = "SCHEMAWIZARD_EXECUTION_LOCK";
+    private final static String EXECUTION_LOCK_NAME = "SCHEMAWIZARD_EXECUTION_LOCK";
 
     @Override
     public String getCreateMigrationHistoryTableSql() {
@@ -102,7 +102,7 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
     }
 
     @Override
-    public String getLockForMigrationExecutionSql() {
+    public String getLockForExecutionSql() {
         return String.format(
                 "DECLARE\n" +
                         "  l_lock_handle VARCHAR2(128);\n" +
@@ -111,7 +111,7 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
                         "  DBMS_LOCK.ALLOCATE_UNIQUE('%s', l_lock_handle);\n" +
                         "  l_result := DBMS_LOCK.REQUEST(l_lock_handle, DBMS_LOCK.X_MODE);\n" +
                         "END;",
-                MIGRATION_EXECUTION_LOCK_NAME);
+                EXECUTION_LOCK_NAME);
     }
 
     @Override

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/OracleHistoryTableQueryFactory.java
@@ -54,7 +54,7 @@ public class OracleHistoryTableQueryFactory implements HistoryTableQueryFactory 
         return String.format("WITH break_row AS (" +
                         "SELECT id FROM %s WHERE %s = ?) " +
                         "SELECT mh.%s, mh.%s, mh.%s, mh.%s, mh.%s " +
-                        "FROM %s " +
+                        "FROM %s mh " +
                         "LEFT JOIN break_row ON (1 = 1) " +
                         "WHERE break_row.%s IS NOT NULL AND mh.%s >= break_row.%s " +
                         "ORDER BY %s DESC",

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
@@ -10,6 +10,9 @@ import static org.schemawizard.core.dao.Constants.MIGRATION_TABLE_NAME;
 import static org.schemawizard.core.dao.Constants.VERSION;
 
 public class PostgresHistoryTableQueryFactory implements HistoryTableQueryFactory {
+    private final static String METADATA_TABLE_NAME = "information_schema.tables";
+    private final static int LOCK_NUMBER = 11111111;
+
     @Override
     public String getCreateMigrationHistoryTableSql() {
         return String.format("CREATE TABLE IF NOT EXISTS %s ("
@@ -31,9 +34,10 @@ public class PostgresHistoryTableQueryFactory implements HistoryTableQueryFactor
     @Override
     public String getSelectTableSql() {
         return String.format("SELECT table_name "
-                        + "FROM information_schema.tables "
+                        + "FROM %s "
                         + "WHERE table_type='BASE TABLE' "
                         + "AND table_name='%s'",
+                METADATA_TABLE_NAME,
                 MIGRATION_TABLE_NAME);
     }
 
@@ -94,5 +98,26 @@ public class PostgresHistoryTableQueryFactory implements HistoryTableQueryFactor
                 "DELETE FROM %s WHERE %s = ?",
                 MIGRATION_TABLE_NAME,
                 VERSION);
+    }
+
+    @Override
+    public String getLockForMigrationExecutionSql() {
+        return String.format(
+                "LOCK TABLE %s IN EXCLUSIVE MODE",
+                MIGRATION_TABLE_NAME);
+    }
+
+    @Override
+    public String getAcquireAdvisoryLockSql() {
+        return String.format(
+                "SELECT pg_advisory_lock(%s)",
+                LOCK_NUMBER);
+    }
+
+    @Override
+    public String getReleaseAdvisoryLockSql() {
+        return String.format(
+                "SELECT pg_advisory_unlock(%s)",
+                LOCK_NUMBER);
     }
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
@@ -101,7 +101,7 @@ public class PostgresHistoryTableQueryFactory implements HistoryTableQueryFactor
     }
 
     @Override
-    public String getLockForMigrationExecutionSql() {
+    public String getLockForExecutionSql() {
         return String.format(
                 "LOCK TABLE %s IN EXCLUSIVE MODE",
                 MIGRATION_TABLE_NAME);

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/PostgresHistoryTableQueryFactory.java
@@ -57,7 +57,7 @@ public class PostgresHistoryTableQueryFactory implements HistoryTableQueryFactor
                         "FROM %s mh " +
                         "LEFT JOIN break_row ON TRUE " +
                         "WHERE break_row.%s IS NOT NULL AND mh.%s >= break_row.%s " +
-                        "ORDER BY %s DESC",
+                        "ORDER BY mh.%s DESC",
                 ID, MIGRATION_TABLE_NAME, VERSION,
                 ID, VERSION, DESCRIPTION, CONTEXT, APPLIED_ON,
                 MIGRATION_TABLE_NAME,

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/TransactionServiceImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/TransactionServiceImpl.java
@@ -6,6 +6,7 @@ import org.schemawizard.core.exception.MigrationApplicationException;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class TransactionServiceImpl implements TransactionService {
@@ -20,6 +21,18 @@ public class TransactionServiceImpl implements TransactionService {
     public <T> T doWithinTransaction(Function<Connection, T> action) {
         try {
             return apply(action);
+        } catch (SQLException exception) {
+            throw new MigrationApplicationException(exception.getMessage(), exception);
+        }
+    }
+
+    @Override
+    public void doWithinTransaction(Consumer<Connection> action) {
+        try {
+            apply(connection -> {
+                action.accept(connection);
+                return null;
+            });
         } catch (SQLException exception) {
             throw new MigrationApplicationException(exception.getMessage(), exception);
         }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/TransactionServiceImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/dao/impl/TransactionServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 public class TransactionServiceImpl implements TransactionService {
     private final ConnectionHolder connectionHolder;
+    private final ThreadLocal<Integer> openedTransactions = ThreadLocal.withInitial(() -> 0);
 
     public TransactionServiceImpl(ConnectionHolder connectionHolder) {
         this.connectionHolder = connectionHolder;
@@ -24,18 +25,37 @@ public class TransactionServiceImpl implements TransactionService {
         }
     }
 
+    @Override
+    public void doWithinTransaction(Runnable action) {
+        try {
+            apply(connection -> {
+                action.run();
+                return null;
+            });
+        } catch (SQLException exception) {
+            throw new MigrationApplicationException(exception.getMessage(), exception);
+        }
+    }
+
     private <T> T apply(Function<Connection, T> action) throws SQLException {
         Connection connection = connectionHolder.getConnection();
+        openedTransactions.set(openedTransactions.get() + 1);
         try {
             connection.setAutoCommit(false);
             T result = action.apply(connection);
-            connection.commit();
+            openedTransactions.set(openedTransactions.get() - 1);
+            if (openedTransactions.get() == 0) {
+                connection.commit();
+            }
             return result;
         } catch (Exception exception) {
+            openedTransactions.set(0);
             connection.rollback();
             throw new MigrationApplicationException(exception.getMessage(), exception);
         } finally {
-            connection.close();
+            if (openedTransactions.get() == 0) {
+                connection.close();
+            }
         }
     }
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/metadata/ErrorMessage.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/metadata/ErrorMessage.java
@@ -48,6 +48,9 @@ public class ErrorMessage {
     public static final String DOWNGRADE_CONTEXT_IS_INVALID_TEMPLATE =
             "The context %s is invalid - no migrations were found to downgrade";
 
+    public static final String UNABLE_TO_LOCK_TABLE_TEMPLATE =
+            "Unable to lock table %s";
+
     private ErrorMessage() {
     }
 }

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/runner/impl/MigrationRunnerImpl.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/runner/impl/MigrationRunnerImpl.java
@@ -1,7 +1,6 @@
 package org.schemawizard.core.runner.impl;
 
 import org.schemawizard.core.analyzer.MigrationData;
-import org.schemawizard.core.analyzer.impl.HistoryTableCreatorImpl;
 import org.schemawizard.core.callback.AfterQueryExecutionCallback;
 import org.schemawizard.core.callback.BeforeQueryExecutionCallback;
 import org.schemawizard.core.dao.HistoryTableQueryFactory;
@@ -14,8 +13,6 @@ import org.schemawizard.core.migration.operation.Operation;
 import org.schemawizard.core.migration.service.OperationResolverService;
 import org.schemawizard.core.model.ConfigurationProperties;
 import org.schemawizard.core.runner.MigrationRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -25,7 +22,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class MigrationRunnerImpl implements MigrationRunner {
-    private final Logger log = LoggerFactory.getLogger(HistoryTableCreatorImpl.class);
     private final MigrationRunnerStrategy upgradeStrategy = new UpgradeMigrationRunnerStrategy();
     private final MigrationRunnerStrategy downgradeStrategy = new DowngradeMigrationRunnerStrategy();
 

--- a/schema-wizard-core/src/main/java/org/schemawizard/core/starter/SchemaWizardBuilder.java
+++ b/schema-wizard-core/src/main/java/org/schemawizard/core/starter/SchemaWizardBuilder.java
@@ -1,11 +1,11 @@
 package org.schemawizard.core.starter;
 
 import org.reflections.Reflections;
-import org.schemawizard.core.analyzer.HistoryTableCreator;
+import org.schemawizard.core.analyzer.HistoryTable;
 import org.schemawizard.core.analyzer.MigrationAnalyzer;
 import org.schemawizard.core.analyzer.factory.DowngradeFactory;
 import org.schemawizard.core.analyzer.factory.impl.DowngradeFactoryImpl;
-import org.schemawizard.core.analyzer.impl.HistoryTableCreatorImpl;
+import org.schemawizard.core.analyzer.impl.HistoryTableImpl;
 import org.schemawizard.core.analyzer.impl.MigrationAnalyzerImpl;
 import org.schemawizard.core.analyzer.service.AppliedMigrationsService;
 import org.schemawizard.core.analyzer.service.DeclaredMigrationService;
@@ -83,7 +83,7 @@ public class SchemaWizardBuilder {
         container.register(AppliedMigrationsService.class, AppliedMigrationsServiceImpl.class);
         container.register(DeclaredMigrationService.class, ClassesDeclaredMigrationService.class);
         container.register(ConnectionHolder.class, ConnectionHolder.class);
-        container.register(HistoryTableCreator.class, HistoryTableCreatorImpl.class);
+        container.register(HistoryTable.class, HistoryTableImpl.class);
         container.register(MigrationAnalyzer.class, MigrationAnalyzerImpl.class);
         container.register(MigrationRunner.class, MigrationRunnerImpl.class);
         container.register(OperationResolverService.class, OperationResolverServiceImpl.class);

--- a/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/HistoryTableImplTest.java
+++ b/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/HistoryTableImplTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.schemawizard.core.analyzer.HistoryTableCreator;
+import org.schemawizard.core.analyzer.HistoryTable;
 import org.schemawizard.core.dao.ConnectionHolder;
 import org.schemawizard.core.dao.impl.PostgresHistoryTableQueryFactory;
 import org.schemawizard.core.model.ConfigurationProperties;
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class HistoryTableCreatorImplTest {
+public class HistoryTableImplTest {
 
     private static final String SELECT_TABLE_SQL = "SELECT table_name " +
             "FROM information_schema.tables " +
@@ -34,7 +34,7 @@ public class HistoryTableCreatorImplTest {
                     .build()
     );
 
-    private final HistoryTableCreator historyTableCreator = new HistoryTableCreatorImpl(
+    private final HistoryTable historyTable = new HistoryTableImpl(
             connectionHolder, new PostgresHistoryTableQueryFactory());
 
     @BeforeAll
@@ -50,13 +50,13 @@ public class HistoryTableCreatorImplTest {
     @Test
     @Order(1)
     void isHistoryTableExistShouldReturnFalseIfTableNotExist() {
-        assertFalse(historyTableCreator.historyTableExists());
+        assertFalse(historyTable.exists());
     }
 
     @Test
     @Order(2)
     void createTableIfNotExistShouldCreateTable() {
-        historyTableCreator.createTableIfNotExist();
+        historyTable.createIfNotExists();
         try (Statement statement = connectionHolder.getConnection().createStatement()) {
             statement.execute(SELECT_TABLE_SQL);
             assertTrue(statement.getResultSet().next());
@@ -68,6 +68,6 @@ public class HistoryTableCreatorImplTest {
     @Test
     @Order(3)
     void isHistoryTableExistShouldReturnTrueIfTableExist() {
-        assertTrue(historyTableCreator.historyTableExists());
+        assertTrue(historyTable.exists());
     }
 }

--- a/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/HistoryTableImplTest.java
+++ b/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/HistoryTableImplTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.schemawizard.core.analyzer.HistoryTable;
 import org.schemawizard.core.dao.ConnectionHolder;
+import org.schemawizard.core.dao.TransactionService;
 import org.schemawizard.core.dao.impl.PostgresHistoryTableQueryFactory;
+import org.schemawizard.core.dao.impl.TransactionServiceImpl;
 import org.schemawizard.core.model.ConfigurationProperties;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -31,11 +33,12 @@ public class HistoryTableImplTest {
                     .connectionUrl(postgres.getJdbcUrl())
                     .username(postgres.getUsername())
                     .password(postgres.getPassword())
-                    .build()
-    );
+                    .build());
+
+    private final TransactionService transactionService = new TransactionServiceImpl(connectionHolder);
 
     private final HistoryTable historyTable = new HistoryTableImpl(
-            connectionHolder, new PostgresHistoryTableQueryFactory());
+            transactionService, new PostgresHistoryTableQueryFactory());
 
     @BeforeAll
     static void setUp() {

--- a/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/MigrationAnalyzerImplTest.java
+++ b/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/impl/MigrationAnalyzerImplTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.schemawizard.core.analyzer.AppliedMigration;
 import org.schemawizard.core.analyzer.DeclaredMigration;
-import org.schemawizard.core.analyzer.HistoryTableCreator;
+import org.schemawizard.core.analyzer.HistoryTable;
 import org.schemawizard.core.analyzer.MigrationAnalyzer;
 import org.schemawizard.core.analyzer.MigrationData;
 import org.schemawizard.core.analyzer.exception.MigrationAnalyzerException;
@@ -30,14 +30,14 @@ public class MigrationAnalyzerImplTest {
 
     private final DeclaredMigrationService declaredMigrationsService = Mockito.mock(DeclaredMigrationService.class);
 
-    private final HistoryTableCreator historyTableCreator = Mockito.mock(HistoryTableCreator.class);
+    private final HistoryTable historyTable = Mockito.mock(HistoryTable.class);
 
     private final DowngradeFactory downgradeFactory = Mockito.mock(DowngradeFactory.class);
 
     private final MigrationAnalyzer migrationAnalyzer = new MigrationAnalyzerImpl(
             appliedMigrationsService,
             declaredMigrationsService,
-            historyTableCreator,
+            historyTable,
             downgradeFactory);
 
     @Test
@@ -195,29 +195,9 @@ public class MigrationAnalyzerImplTest {
         assertThrows(MigrationAnalyzerException.class, migrationAnalyzer::upgradeAnalyze);
     }
 
-    private List<AppliedMigration> createTwoAppliedMigrationDescOrder() {
-        AppliedMigration appliedMigration2 = new AppliedMigration(
-                2,
-                2,
-                "second migration",
-                "context",
-                LocalDateTime.now()
-        );
-
-        AppliedMigration appliedMigration3 = new AppliedMigration(
-                3,
-                3,
-                "third migration",
-                "context",
-                LocalDateTime.now()
-        );
-
-        return List.of(appliedMigration3, appliedMigration2);
-    }
-
     @Test
     void downgradeAnalyzeShouldThrowExceptionIfHistoryTableDoesNotExist() {
-        when(historyTableCreator.historyTableExists()).thenReturn(false);
+        when(historyTable.exists()).thenReturn(false);
         assertThrows(MigrationAnalyzerException.class, () -> migrationAnalyzer.downgradeAnalyze(new VersionDowngradeStrategyParameters(2)));
     }
 

--- a/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/service/impl/AppliedMigrationsServiceImplTest.java
+++ b/schema-wizard-core/src/test/java/org/schemawizard/core/analyzer/service/impl/AppliedMigrationsServiceImplTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.schemawizard.core.analyzer.AppliedMigration;
 import org.schemawizard.core.analyzer.service.AppliedMigrationsService;
 import org.schemawizard.core.dao.ConnectionHolder;
+import org.schemawizard.core.dao.TransactionService;
 import org.schemawizard.core.dao.impl.PostgresHistoryTableQueryFactory;
+import org.schemawizard.core.dao.impl.TransactionServiceImpl;
 import org.schemawizard.core.model.ConfigurationProperties;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -46,8 +48,10 @@ public class AppliedMigrationsServiceImplTest {
                     .password(postgres.getPassword())
                     .build());
 
+    private final TransactionService transactionService = new TransactionServiceImpl(connectionHolder);
+
     private final AppliedMigrationsService appliedMigrationsService = new AppliedMigrationsServiceImpl(
-            connectionHolder, new PostgresHistoryTableQueryFactory());
+            transactionService, new PostgresHistoryTableQueryFactory());
 
     @BeforeAll
     static void setUp() {

--- a/schema-wizard-example/src/main/java/com/example/MigrationUsageApplication.java
+++ b/schema-wizard-example/src/main/java/com/example/MigrationUsageApplication.java
@@ -3,8 +3,6 @@ package com.example;
 import org.schemawizard.core.starter.SchemaWizard;
 import org.schemawizard.core.starter.SchemaWizardBuilder;
 
-import java.sql.SQLException;
-
 public class MigrationUsageApplication {
     public static void main(String[] args) throws InterruptedException {
         SchemaWizard first = SchemaWizardBuilder.init().build();

--- a/schema-wizard-example/src/main/java/com/example/MigrationUsageApplication.java
+++ b/schema-wizard-example/src/main/java/com/example/MigrationUsageApplication.java
@@ -3,10 +3,20 @@ package com.example;
 import org.schemawizard.core.starter.SchemaWizard;
 import org.schemawizard.core.starter.SchemaWizardBuilder;
 
+import java.sql.SQLException;
+
 public class MigrationUsageApplication {
-    public static void main(String[] args) {
-        SchemaWizard schemaWizard = SchemaWizardBuilder.init()
-                .build();
-        schemaWizard.up();
+    public static void main(String[] args) throws InterruptedException {
+        SchemaWizard first = SchemaWizardBuilder.init().build();
+        SchemaWizard second = SchemaWizardBuilder.init().build();
+
+        Thread firstThread = new Thread(first::up);
+        Thread secondThread = new Thread(second::up);
+
+        firstThread.start();
+        secondThread.start();
+
+        firstThread.join();
+        secondThread.join();
     }
 }


### PR DESCRIPTION
[UPGRADE] Logs output on PostgreSQL:
![image](https://github.com/AndriyBosik/schema-wizard/assets/55958195/25a2553a-6a80-44fc-ae2e-c5471162d23b)

[UPGRADE] Logs output on Oracle:
![image](https://github.com/AndriyBosik/schema-wizard/assets/55958195/2c0a40da-b1e0-4b37-a599-4d0684f40a20)

[DOWNGRADE] Logs output on PostgreSQL:
![image](https://github.com/AndriyBosik/schema-wizard/assets/55958195/8c242c83-cb83-4417-a163-ec752c41139b)

[DOWNGRADE] Logs output on Oracle:
![image](https://github.com/AndriyBosik/schema-wizard/assets/55958195/163ec8d2-6f14-41bb-882d-c70f2bee28f0)
